### PR TITLE
Add spectEventName to handler's payload

### DIFF
--- a/.spec/handlers/index.js
+++ b/.spec/handlers/index.js
@@ -5,6 +5,7 @@ const relayEventToWebhook = require("./reporter")
  */
 async function processOnChainItem(event, db, logger) {
   const payload = {
+    specEventName: event.name,
     chainId: Number(event.origin.chainId),
     transactionHash: event.origin.transactionHash,
     contractAddress: event.origin.contractAddress,


### PR DESCRIPTION
To merge with https://github.com/0xStation/membership/pull/172

* added `specEventName` processQueueItem`'s payload. Used in the membership app to detect contract's emitted event